### PR TITLE
CAL-132 Add NITF TRE support for CSEXRA, PIAIMC, CSDIDA

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/org/codice/alliance/catalog/core/api/impl/types/IsrAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/org/codice/alliance/catalog/core/api/impl/types/IsrAttributes.java
@@ -39,24 +39,6 @@ public class IsrAttributes implements Isr, MetacardType {
                 false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.INTEGER_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(SNOW_COVER,
-                true /* indexed */,
-                true /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.BOOLEAN_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(SNOW_DEPTH_MIN,
-                true /* indexed */,
-                true /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.DOUBLE_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(SNOW_DEPTH_MAX,
-                true /* indexed */,
-                true /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.DOUBLE_TYPE));
         DESCRIPTORS.add(new AttributeDescriptorImpl(VIDEO_MOVING_TARGET_INDICATOR_PROCESSED,
                 true /* indexed */,
                 true /* stored */,
@@ -249,6 +231,24 @@ public class IsrAttributes implements Isr, MetacardType {
                 true /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
+        DESCRIPTORS.add(new AttributeDescriptorImpl(SNOW_COVER,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.BOOLEAN_TYPE));
+        DESCRIPTORS.add(new AttributeDescriptorImpl(SNOW_DEPTH_MIN_CENTIMETERS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.DOUBLE_TYPE));
+        DESCRIPTORS.add(new AttributeDescriptorImpl(SNOW_DEPTH_MAX_CENTIMETERS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.DOUBLE_TYPE));
         DESCRIPTORS.add(new AttributeDescriptorImpl(TARGET_CATEGORY_CODE,
                 true /* indexed */,
                 true /* stored */,

--- a/catalog/core/catalog-core-api-impl/src/main/java/org/codice/alliance/catalog/core/api/impl/types/IsrAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/org/codice/alliance/catalog/core/api/impl/types/IsrAttributes.java
@@ -39,6 +39,24 @@ public class IsrAttributes implements Isr, MetacardType {
                 false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.INTEGER_TYPE));
+        DESCRIPTORS.add(new AttributeDescriptorImpl(SNOW_COVER,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.BOOLEAN_TYPE));
+        DESCRIPTORS.add(new AttributeDescriptorImpl(SNOW_DEPTH_MIN,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.DOUBLE_TYPE));
+        DESCRIPTORS.add(new AttributeDescriptorImpl(SNOW_DEPTH_MAX,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.DOUBLE_TYPE));
         DESCRIPTORS.add(new AttributeDescriptorImpl(VIDEO_MOVING_TARGET_INDICATOR_PROCESSED,
                 true /* indexed */,
                 true /* stored */,

--- a/catalog/core/catalog-core-api/src/main/java/org/codice/alliance/catalog/core/api/types/Isr.java
+++ b/catalog/core/catalog-core-api/src/main/java/org/codice/alliance/catalog/core/api/types/Isr.java
@@ -27,6 +27,21 @@ public interface Isr {
     String CLOUD_COVER = "isr.cloud-cover";
 
     /**
+     * Attribute name for accessing the snow cover existence for this Metacard. <br/>
+     */
+    String SNOW_COVER = "isr.snow-cover";
+
+    /**
+     * Attribute name for accessing the minimum snow depth (centimeters) for this Metacard. <br/>
+     */
+    String SNOW_DEPTH_MIN = "isr.snow-depth-min";
+
+    /**
+     * Attribute name for accessing the maximum snow depth (centimeters) for this Metacard. <br/>
+     */
+    String SNOW_DEPTH_MAX = "isr.snow-depth-max";
+
+    /**
      * Attribute name for accessing whether the imagery has been processed for VMTI for this Metacard. <br/>
      */
     String VIDEO_MOVING_TARGET_INDICATOR_PROCESSED = "isr.vmti-processed";

--- a/catalog/core/catalog-core-api/src/main/java/org/codice/alliance/catalog/core/api/types/Isr.java
+++ b/catalog/core/catalog-core-api/src/main/java/org/codice/alliance/catalog/core/api/types/Isr.java
@@ -27,21 +27,6 @@ public interface Isr {
     String CLOUD_COVER = "isr.cloud-cover";
 
     /**
-     * Attribute name for accessing the snow cover existence for this Metacard. <br/>
-     */
-    String SNOW_COVER = "isr.snow-cover";
-
-    /**
-     * Attribute name for accessing the minimum snow depth (centimeters) for this Metacard. <br/>
-     */
-    String SNOW_DEPTH_MIN = "isr.snow-depth-min";
-
-    /**
-     * Attribute name for accessing the maximum snow depth (centimeters) for this Metacard. <br/>
-     */
-    String SNOW_DEPTH_MAX = "isr.snow-depth-max";
-
-    /**
      * Attribute name for accessing whether the imagery has been processed for VMTI for this Metacard. <br/>
      */
     String VIDEO_MOVING_TARGET_INDICATOR_PROCESSED = "isr.vmti-processed";
@@ -202,6 +187,21 @@ public interface Isr {
      * Attribute name for accessing the sensor type for this Metacard. <br/>
      */
     String SENSOR_TYPE = "isr.sensor-type";
+
+    /**
+     * Attribute name for accessing the snow cover existence for this Metacard. <br/>
+     */
+    String SNOW_COVER = "isr.snow-cover";
+
+    /**
+     * Attribute name for accessing the minimum snow depth (centimeters) for this Metacard. <br/>
+     */
+    String SNOW_DEPTH_MIN_CENTIMETERS = "isr.snow-depth-min-centimeters";
+
+    /**
+     * Attribute name for accessing the maximum snow depth (centimeters) for this Metacard. <br/>
+     */
+    String SNOW_DEPTH_MAX_CENTIMETERS = "isr.snow-depth-max-centimeters";
 
     /**
      * Attribute name for accessing the target category code for this Metacard. <br/>

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/Constants.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/Constants.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.common;
+
+import java.util.regex.Pattern;
+
+public class Constants {
+
+    static final Pattern NIIRS_FORMAT = Pattern.compile("^[0-9]\\.[0-9]$");
+
+    static final String GRD_COVER = "GRD_COVER";
+
+    static final String SNOW_DEPTH_CAT = "SNOW_DEPTH_CAT";
+
+    static final String PREDICTED_NIIRS = "PREDICTED_NIIRS";
+
+    static final String SYSTYPE = "SYSTYPE";
+
+    static final String CLOUDCVR = "CLOUDCVR";
+
+    static final String PLATFORM_CODE = "PLATFORM CODE";
+
+    static final String VEHICLE_ID = "VEHICLE ID";
+
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/CsdidaAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/CsdidaAttribute.java
@@ -28,10 +28,10 @@ enum CsdidaAttribute implements NitfAttribute<Tre> {
 
     PLATFORM_ID(Isr.PLATFORM_ID, "PLATFORM_CODE_VEHICLE_ID", tre -> {
         Optional<String> platformCode = Optional.ofNullable(TreUtility.getTreValue(tre,
-                Constants.PLATFORM_CODE))
+                NitfConstants.PLATFORM_CODE))
                 .filter(String.class::isInstance)
                 .map(String.class::cast);
-        Optional<Integer> vehicleId = TreUtility.findIntValue(tre, Constants.VEHICLE_ID);
+        Optional<Integer> vehicleId = TreUtility.findIntValue(tre, NitfConstants.VEHICLE_ID);
 
         if (platformCode.isPresent() && vehicleId.isPresent()) {
             return platformCode.get() + String.format("%02d", vehicleId.get());

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/CsdidaAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/CsdidaAttribute.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.common;
+
+import java.io.Serializable;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
+import org.codice.alliance.catalog.core.api.types.Isr;
+import org.codice.imaging.nitf.core.tre.Tre;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.MetacardType;
+
+enum CsdidaAttribute implements NitfAttribute<Tre> {
+
+    PLATFORM_ID(Isr.PLATFORM_ID, "PLATFORM_CODE_VEHICLE_ID", tre -> {
+        Optional<String> platformCode = Optional.ofNullable(TreUtility.getTreValue(tre,
+                Constants.PLATFORM_CODE))
+                .filter(String.class::isInstance)
+                .map(String.class::cast);
+        Optional<Integer> vehicleId = TreUtility.findIntValue(tre, Constants.VEHICLE_ID);
+
+        if (platformCode.isPresent() && vehicleId.isPresent()) {
+            return platformCode.get() + String.format("%02d", vehicleId.get());
+        }
+
+        return null;
+    }, new IsrAttributes());
+
+    private String shortName;
+
+    private String longName;
+
+    private Function<Tre, Serializable> accessorFunction;
+
+    private AttributeDescriptor attributeDescriptor;
+
+    CsdidaAttribute(String longName, String shortName, Function<Tre, Serializable> accessorFunction,
+            MetacardType metacardType) {
+        this.longName = longName;
+        this.shortName = shortName;
+        this.accessorFunction = accessorFunction;
+        // retrieving metacard attribute descriptor for this attribute to prevent later lookups
+        this.attributeDescriptor = metacardType.getAttributeDescriptor(longName);
+    }
+
+    @Override
+    public String getLongName() {
+        return longName;
+    }
+
+    @Override
+    public String getShortName() {
+        return shortName;
+    }
+
+    @Override
+    public Function<Tre, Serializable> getAccessorFunction() {
+        return accessorFunction;
+    }
+
+    @Override
+    public AttributeDescriptor getAttributeDescriptor() {
+        return attributeDescriptor;
+    }
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/CsexraAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/CsexraAttribute.java
@@ -31,25 +31,25 @@ import ddf.catalog.data.MetacardType;
 enum CsexraAttribute implements NitfAttribute<Tre> {
 
     @SuppressWarnings("RedundantTypeArguments")
-    SNOW_DEPTH_MIN(Isr.SNOW_DEPTH_MIN,
-            Constants.SNOW_DEPTH_CAT,
+    SNOW_DEPTH_MIN(Isr.SNOW_DEPTH_MIN_CENTIMETERS,
+            NitfConstants.SNOW_DEPTH_CAT,
             getSnowDepthAccessorFunction(Pair<Double, Double>::getLeft),
             new IsrAttributes()),
     @SuppressWarnings("RedundantTypeArguments")
-    SNOW_DEPTH_MAX(Isr.SNOW_DEPTH_MAX,
-            Constants.SNOW_DEPTH_CAT,
+    SNOW_DEPTH_MAX(Isr.SNOW_DEPTH_MAX_CENTIMETERS,
+            NitfConstants.SNOW_DEPTH_CAT,
             getSnowDepthAccessorFunction(Pair<Double, Double>::getRight),
             new IsrAttributes()),
     PREDICTED_NIIRS(Isr.NATIONAL_IMAGERY_INTERPRETABILITY_RATING_SCALE,
-            Constants.PREDICTED_NIIRS, tre -> {
-        return Optional.ofNullable(TreUtility.getTreValue(tre, Constants.PREDICTED_NIIRS))
+            NitfConstants.PREDICTED_NIIRS, tre -> {
+        return Optional.ofNullable(TreUtility.getTreValue(tre, NitfConstants.PREDICTED_NIIRS))
             .filter(String.class::isInstance)
             .map(String.class::cast)
             .map(CsexraAttribute::parseNiirs)
             .orElse(null);
     }, new IsrAttributes()),
-    SNOW_COVER(Isr.SNOW_COVER, Constants.GRD_COVER, tre -> {
-        return TreUtility.findIntValue(tre, Constants.GRD_COVER)
+    SNOW_COVER(Isr.SNOW_COVER, NitfConstants.GRD_COVER, tre -> {
+        return TreUtility.findIntValue(tre, NitfConstants.GRD_COVER)
                 .map(value -> {
                     switch (value) {
                     case 0:
@@ -83,7 +83,7 @@ enum CsexraAttribute implements NitfAttribute<Tre> {
     }
 
     private static Integer parseNiirs(String niirs) {
-        return Constants.NIIRS_FORMAT.matcher(niirs)
+        return NitfConstants.NIIRS_FORMAT.matcher(niirs)
                 .matches() ?
                 Double.valueOf(niirs)
                         .intValue() :
@@ -96,7 +96,7 @@ enum CsexraAttribute implements NitfAttribute<Tre> {
 
     private static Function<Tre, Serializable> getSnowDepthAccessorFunction(
             Function<Pair, Double> pairFunction) {
-        return tre -> TreUtility.findIntValue(tre, Constants.SNOW_DEPTH_CAT)
+        return tre -> TreUtility.findIntValue(tre, NitfConstants.SNOW_DEPTH_CAT)
                 .map(CsexraAttribute::convertSnowDepthCat)
                 .map(doubleDoublePair -> doubleDoublePair.map(pairFunction)
                         .orElse(null))

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/CsexraAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/CsexraAttribute.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.common;
+
+import java.io.Serializable;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
+import org.codice.alliance.catalog.core.api.types.Isr;
+import org.codice.imaging.nitf.core.tre.Tre;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.MetacardType;
+
+enum CsexraAttribute implements NitfAttribute<Tre> {
+
+    @SuppressWarnings("RedundantTypeArguments")
+    SNOW_DEPTH_MIN(Isr.SNOW_DEPTH_MIN,
+            Constants.SNOW_DEPTH_CAT,
+            getSnowDepthAccessorFunction(Pair<Double, Double>::getLeft),
+            new IsrAttributes()),
+    @SuppressWarnings("RedundantTypeArguments")
+    SNOW_DEPTH_MAX(Isr.SNOW_DEPTH_MAX,
+            Constants.SNOW_DEPTH_CAT,
+            getSnowDepthAccessorFunction(Pair<Double, Double>::getRight),
+            new IsrAttributes()),
+    PREDICTED_NIIRS(Isr.NATIONAL_IMAGERY_INTERPRETABILITY_RATING_SCALE,
+            Constants.PREDICTED_NIIRS, tre -> {
+        return Optional.ofNullable(TreUtility.getTreValue(tre, Constants.PREDICTED_NIIRS))
+            .filter(String.class::isInstance)
+            .map(String.class::cast)
+            .map(CsexraAttribute::parseNiirs)
+            .orElse(null);
+    }, new IsrAttributes()),
+    SNOW_COVER(Isr.SNOW_COVER, Constants.GRD_COVER, tre -> {
+        return TreUtility.findIntValue(tre, Constants.GRD_COVER)
+                .map(value -> {
+                    switch (value) {
+                    case 0:
+                        return Boolean.FALSE;
+                    case 1:
+                        return Boolean.TRUE;
+                    default:
+                        return null;
+                    }
+                })
+                .orElse(null);
+    }, new IsrAttributes());
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CsexraAttribute.class);
+
+    private String shortName;
+
+    private String longName;
+
+    private Function<Tre, Serializable> accessorFunction;
+
+    private AttributeDescriptor attributeDescriptor;
+
+    CsexraAttribute(String longName, String shortName, Function<Tre, Serializable> accessorFunction,
+            MetacardType metacardType) {
+        this.longName = longName;
+        this.shortName = shortName;
+        this.accessorFunction = accessorFunction;
+        // retrieving metacard attribute descriptor for this attribute to prevent later lookups
+        this.attributeDescriptor = metacardType.getAttributeDescriptor(longName);
+    }
+
+    private static Integer parseNiirs(String niirs) {
+        return Constants.NIIRS_FORMAT.matcher(niirs)
+                .matches() ?
+                Double.valueOf(niirs)
+                        .intValue() :
+                null;
+    }
+
+    private static double inchesToCentimeters(double inches) {
+        return inches * 2.54;
+    }
+
+    private static Function<Tre, Serializable> getSnowDepthAccessorFunction(
+            Function<Pair, Double> pairFunction) {
+        return tre -> TreUtility.findIntValue(tre, Constants.SNOW_DEPTH_CAT)
+                .map(CsexraAttribute::convertSnowDepthCat)
+                .map(doubleDoublePair -> doubleDoublePair.map(pairFunction)
+                        .orElse(null))
+                .orElse(null);
+    }
+
+    private static Optional<Pair<Double, Double>> convertSnowDepthCat(int category) {
+        switch (category) {
+        case 0:
+            return Optional.of(new ImmutablePair<>(inchesToCentimeters(0), inchesToCentimeters(1)));
+        case 1:
+            return Optional.of(new ImmutablePair<>(inchesToCentimeters(1), inchesToCentimeters(9)));
+        case 2:
+            return Optional.of(new ImmutablePair<>(inchesToCentimeters(9),
+                    inchesToCentimeters(17)));
+        case 3:
+            return Optional.of(new ImmutablePair<>(inchesToCentimeters(17), Double.MAX_VALUE));
+        default:
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public String getLongName() {
+        return longName;
+    }
+
+    @Override
+    public String getShortName() {
+        return shortName;
+    }
+
+    @Override
+    public Function<Tre, Serializable> getAccessorFunction() {
+        return accessorFunction;
+    }
+
+    @Override
+    public AttributeDescriptor getAttributeDescriptor() {
+        return attributeDescriptor;
+    }
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/NitfConstants.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/NitfConstants.java
@@ -15,7 +15,7 @@ package org.codice.alliance.transformer.nitf.common;
 
 import java.util.regex.Pattern;
 
-public class Constants {
+class NitfConstants {
 
     static final Pattern NIIRS_FORMAT = Pattern.compile("^[0-9]\\.[0-9]$");
 
@@ -32,5 +32,9 @@ public class Constants {
     static final String PLATFORM_CODE = "PLATFORM CODE";
 
     static final String VEHICLE_ID = "VEHICLE ID";
+
+    private NitfConstants() {
+
+    }
 
 }

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/PiaimcAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/PiaimcAttribute.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.common;
+
+import java.io.Serializable;
+import java.util.function.Function;
+
+import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
+import org.codice.alliance.catalog.core.api.types.Isr;
+import org.codice.imaging.nitf.core.tre.Tre;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.MetacardType;
+
+enum PiaimcAttribute implements NitfAttribute<Tre> {
+    CLOUDCVR(Isr.CLOUD_COVER, Constants.CLOUDCVR, tre -> {
+        return TreUtility.findIntValue(tre, Constants.CLOUDCVR)
+                .filter(value -> value >= 0)
+                .filter(value -> value <= 100)
+                .orElse(null);
+    }, new IsrAttributes());
+
+    private String shortName;
+
+    private String longName;
+
+    private Function<Tre, Serializable> accessorFunction;
+
+    private AttributeDescriptor attributeDescriptor;
+
+    PiaimcAttribute(String longName, String shortName, Function<Tre, Serializable> accessorFunction,
+            MetacardType metacardType) {
+        this.longName = longName;
+        this.shortName = shortName;
+        this.accessorFunction = accessorFunction;
+        // retrieving metacard attribute descriptor for this attribute to prevent later lookups
+        this.attributeDescriptor = metacardType.getAttributeDescriptor(longName);
+    }
+
+    @Override
+    public String getLongName() {
+        return longName;
+    }
+
+    @Override
+    public String getShortName() {
+        return shortName;
+    }
+
+    @Override
+    public Function<Tre, Serializable> getAccessorFunction() {
+        return accessorFunction;
+    }
+
+    @Override
+    public AttributeDescriptor getAttributeDescriptor() {
+        return attributeDescriptor;
+    }
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/PiaimcAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/PiaimcAttribute.java
@@ -24,8 +24,8 @@ import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.MetacardType;
 
 enum PiaimcAttribute implements NitfAttribute<Tre> {
-    CLOUDCVR(Isr.CLOUD_COVER, Constants.CLOUDCVR, tre -> {
-        return TreUtility.findIntValue(tre, Constants.CLOUDCVR)
+    CLOUDCVR(Isr.CLOUD_COVER, NitfConstants.CLOUDCVR, tre -> {
+        return TreUtility.findIntValue(tre, NitfConstants.CLOUDCVR)
                 .filter(value -> value >= 0)
                 .filter(value -> value <= 100)
                 .orElse(null);

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/TreDescriptor.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/TreDescriptor.java
@@ -21,7 +21,10 @@ import org.codice.imaging.nitf.core.tre.Tre;
 public enum TreDescriptor {
     ACFTB(AcftbAttribute.values()),
     AIMIDB(AimidbAttribute.values()),
-    MTIRPB(MtirpbAttribute.values());
+    MTIRPB(MtirpbAttribute.values()),
+    CSEXRA(CsexraAttribute.values()),
+    PIAIMC(PiaimcAttribute.values()),
+    CSDIDA(CsdidaAttribute.values());
 
     private NitfAttribute<Tre>[] nitfAttributes;
 

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/TreUtility.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/TreUtility.java
@@ -14,8 +14,10 @@
 package org.codice.alliance.transformer.nitf.common;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 import org.codice.imaging.nitf.core.common.NitfFormatException;
+import org.codice.imaging.nitf.core.tre.Tre;
 import org.codice.imaging.nitf.core.tre.TreGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,5 +42,14 @@ public final class TreUtility {
         }
 
         return null;
+    }
+
+    static Optional<Integer> findIntValue(Tre tre, String tagName) {
+        try {
+            return Optional.of(tre.getIntValue(tagName));
+        } catch (NitfFormatException e) {
+            LOGGER.debug("failed to find {}", tagName, e);
+        }
+        return Optional.empty();
     }
 }

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/TestCommonTreAttributes.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/TestCommonTreAttributes.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 package org.codice.alliance.transformer.nitf;
 
 import static org.hamcrest.core.IsNull.notNullValue;

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/CsdidaAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/CsdidaAttributeTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.common;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+
+import org.codice.imaging.nitf.core.common.NitfFormatException;
+import org.codice.imaging.nitf.core.tre.Tre;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CsdidaAttributeTest {
+
+    private static final String PLATFORM_CODE = "XY";
+
+    private static final Integer VEHICLE_ID = 2;
+
+    private Tre tre;
+
+    @Before
+    public void setup() {
+        tre = mock(Tre.class);
+    }
+
+    @Test
+    public void testPlatformIdBothSet() throws NitfFormatException {
+        when(tre.getFieldValue(Constants.PLATFORM_CODE)).thenReturn(PLATFORM_CODE);
+        when(tre.getIntValue(Constants.VEHICLE_ID)).thenReturn(VEHICLE_ID);
+
+        Serializable actual = CsdidaAttribute.PLATFORM_ID.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is("XY02"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testPlatformIdPlatformOnly() throws NitfFormatException {
+        when(tre.getFieldValue(Constants.PLATFORM_CODE)).thenReturn(PLATFORM_CODE);
+        when(tre.getIntValue(Constants.VEHICLE_ID)).thenThrow(NitfFormatException.class);
+
+        Serializable actual = CsdidaAttribute.PLATFORM_ID.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, nullValue());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testPlatformIdVehicleOnly() throws NitfFormatException {
+        when(tre.getFieldValue(Constants.PLATFORM_CODE)).thenThrow(NitfFormatException.class);
+        when(tre.getIntValue(Constants.VEHICLE_ID)).thenReturn(VEHICLE_ID);
+
+        Serializable actual = CsdidaAttribute.PLATFORM_ID.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, nullValue());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testPlatformIdNeitherSet() throws NitfFormatException {
+        when(tre.getFieldValue(Constants.PLATFORM_CODE)).thenThrow(NitfFormatException.class);
+        when(tre.getIntValue(Constants.VEHICLE_ID)).thenThrow(NitfFormatException.class);
+
+        Serializable actual = CsdidaAttribute.PLATFORM_ID.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, nullValue());
+    }
+
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/CsdidaAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/CsdidaAttributeTest.java
@@ -41,8 +41,8 @@ public class CsdidaAttributeTest {
 
     @Test
     public void testPlatformIdBothSet() throws NitfFormatException {
-        when(tre.getFieldValue(Constants.PLATFORM_CODE)).thenReturn(PLATFORM_CODE);
-        when(tre.getIntValue(Constants.VEHICLE_ID)).thenReturn(VEHICLE_ID);
+        when(tre.getFieldValue(NitfConstants.PLATFORM_CODE)).thenReturn(PLATFORM_CODE);
+        when(tre.getIntValue(NitfConstants.VEHICLE_ID)).thenReturn(VEHICLE_ID);
 
         Serializable actual = CsdidaAttribute.PLATFORM_ID.getAccessorFunction()
                 .apply(tre);
@@ -53,8 +53,8 @@ public class CsdidaAttributeTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testPlatformIdPlatformOnly() throws NitfFormatException {
-        when(tre.getFieldValue(Constants.PLATFORM_CODE)).thenReturn(PLATFORM_CODE);
-        when(tre.getIntValue(Constants.VEHICLE_ID)).thenThrow(NitfFormatException.class);
+        when(tre.getFieldValue(NitfConstants.PLATFORM_CODE)).thenReturn(PLATFORM_CODE);
+        when(tre.getIntValue(NitfConstants.VEHICLE_ID)).thenThrow(NitfFormatException.class);
 
         Serializable actual = CsdidaAttribute.PLATFORM_ID.getAccessorFunction()
                 .apply(tre);
@@ -65,8 +65,8 @@ public class CsdidaAttributeTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testPlatformIdVehicleOnly() throws NitfFormatException {
-        when(tre.getFieldValue(Constants.PLATFORM_CODE)).thenThrow(NitfFormatException.class);
-        when(tre.getIntValue(Constants.VEHICLE_ID)).thenReturn(VEHICLE_ID);
+        when(tre.getFieldValue(NitfConstants.PLATFORM_CODE)).thenThrow(NitfFormatException.class);
+        when(tre.getIntValue(NitfConstants.VEHICLE_ID)).thenReturn(VEHICLE_ID);
 
         Serializable actual = CsdidaAttribute.PLATFORM_ID.getAccessorFunction()
                 .apply(tre);
@@ -77,8 +77,8 @@ public class CsdidaAttributeTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testPlatformIdNeitherSet() throws NitfFormatException {
-        when(tre.getFieldValue(Constants.PLATFORM_CODE)).thenThrow(NitfFormatException.class);
-        when(tre.getIntValue(Constants.VEHICLE_ID)).thenThrow(NitfFormatException.class);
+        when(tre.getFieldValue(NitfConstants.PLATFORM_CODE)).thenThrow(NitfFormatException.class);
+        when(tre.getIntValue(NitfConstants.VEHICLE_ID)).thenThrow(NitfFormatException.class);
 
         Serializable actual = CsdidaAttribute.PLATFORM_ID.getAccessorFunction()
                 .apply(tre);

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/CsexraAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/CsexraAttributeTest.java
@@ -1,0 +1,242 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.common;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+
+import org.codice.imaging.nitf.core.common.NitfFormatException;
+import org.codice.imaging.nitf.core.tre.Tre;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CsexraAttributeTest {
+
+    private static final Double DELTA = 0.01;
+
+    private Tre tre;
+
+    @Before
+    public void setup() {
+        tre = mock(Tre.class);
+    }
+
+    @Test
+    public void testGroundCoverTrue() throws NitfFormatException {
+        when(tre.getIntValue(Constants.GRD_COVER)).thenReturn(1);
+        Serializable actual = CsexraAttribute.SNOW_COVER.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(instanceOf(Boolean.class)));
+        assertThat(actual, is(Boolean.TRUE));
+    }
+
+    @Test
+    public void testGroundCoverFalse() throws NitfFormatException {
+        when(tre.getIntValue(Constants.GRD_COVER)).thenReturn(0);
+        Serializable actual = CsexraAttribute.SNOW_COVER.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(instanceOf(Boolean.class)));
+        assertThat(actual, is(Boolean.FALSE));
+    }
+
+    @Test
+    public void testGroundCoverOther() throws NitfFormatException {
+        when(tre.getIntValue(Constants.GRD_COVER)).thenReturn(5);
+        Serializable actual = CsexraAttribute.SNOW_COVER.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testGroundCoverNotSet() throws NitfFormatException {
+        when(tre.getIntValue(Constants.GRD_COVER)).thenThrow(NitfFormatException.class);
+        Serializable actual = CsexraAttribute.SNOW_COVER.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testNiirs() throws NitfFormatException {
+        when(tre.getFieldValue(Constants.PREDICTED_NIIRS)).thenReturn("3.1");
+
+        Serializable actual = CsexraAttribute.PREDICTED_NIIRS.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is(instanceOf(Integer.class)));
+        assertThat(actual, is(3));
+
+    }
+
+    @Test
+    public void testNiirsOther() throws NitfFormatException {
+        when(tre.getFieldValue(Constants.PREDICTED_NIIRS)).thenReturn("N/A");
+
+        Serializable actual = CsexraAttribute.PREDICTED_NIIRS.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is(nullValue()));
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testNiirsNotSet() throws NitfFormatException {
+        when(tre.getFieldValue(Constants.PREDICTED_NIIRS)).thenThrow(NitfFormatException.class);
+
+        Serializable actual = CsexraAttribute.PREDICTED_NIIRS.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is(nullValue()));
+
+    }
+
+    @Test
+    public void testSnowDepthMinCategory0() throws NitfFormatException {
+        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(0);
+
+        Serializable actual = CsexraAttribute.SNOW_DEPTH_MIN.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is(instanceOf(Double.class)));
+        assertThat((Double) actual, is(closeTo(0, DELTA)));
+    }
+
+    @Test
+    public void testSnowDepthMinCategory1() throws NitfFormatException {
+        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(1);
+
+        Serializable actual = CsexraAttribute.SNOW_DEPTH_MIN.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is(instanceOf(Double.class)));
+        assertThat((Double) actual, is(closeTo(2.54, DELTA)));
+    }
+
+    @Test
+    public void testSnowDepthMinCategory2() throws NitfFormatException {
+        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(2);
+
+        Serializable actual = CsexraAttribute.SNOW_DEPTH_MIN.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is(instanceOf(Double.class)));
+        assertThat((Double) actual, is(closeTo(22.86, DELTA)));
+    }
+
+    @Test
+    public void testSnowDepthMinCategory3() throws NitfFormatException {
+        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(3);
+
+        Serializable actual = CsexraAttribute.SNOW_DEPTH_MIN.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is(instanceOf(Double.class)));
+        assertThat((Double) actual, is(closeTo(43.18, DELTA)));
+    }
+
+    @Test
+    public void testSnowDepthMinCategoryOther() throws NitfFormatException {
+        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(10);
+
+        Serializable actual = CsexraAttribute.SNOW_DEPTH_MIN.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is(nullValue()));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSnowDepthMinCategoryNotSet() throws NitfFormatException {
+        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenThrow(NitfFormatException.class);
+
+        Serializable actual = CsexraAttribute.SNOW_DEPTH_MIN.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testSnowDepthMaxCategory0() throws NitfFormatException {
+        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(0);
+
+        Serializable actual = CsexraAttribute.SNOW_DEPTH_MAX.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is(instanceOf(Double.class)));
+        assertThat((Double) actual, is(closeTo(2.54, DELTA)));
+    }
+
+    @Test
+    public void testSnowDepthMaxCategory1() throws NitfFormatException {
+        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(1);
+
+        Serializable actual = CsexraAttribute.SNOW_DEPTH_MAX.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is(instanceOf(Double.class)));
+        assertThat((Double) actual, is(closeTo(22.86, DELTA)));
+    }
+
+    @Test
+    public void testSnowDepthMaxCategory2() throws NitfFormatException {
+        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(2);
+
+        Serializable actual = CsexraAttribute.SNOW_DEPTH_MAX.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is(instanceOf(Double.class)));
+        assertThat((Double) actual, is(closeTo(43.18, DELTA)));
+    }
+
+    @Test
+    public void testSnowDepthMaxCategory3() throws NitfFormatException {
+        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(3);
+
+        Serializable actual = CsexraAttribute.SNOW_DEPTH_MAX.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is(instanceOf(Double.class)));
+        assertThat((Double) actual, is(closeTo(Double.MAX_VALUE, DELTA)));
+    }
+
+    @Test
+    public void testSnowDepthMaxCategoryOther() throws NitfFormatException {
+        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(10);
+
+        Serializable actual = CsexraAttribute.SNOW_DEPTH_MAX.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is(nullValue()));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSnowDepthMaxCategoryNotSet() throws NitfFormatException {
+        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenThrow(NitfFormatException.class);
+
+        Serializable actual = CsexraAttribute.SNOW_DEPTH_MAX.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is(nullValue()));
+    }
+
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/CsexraAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/CsexraAttributeTest.java
@@ -41,7 +41,7 @@ public class CsexraAttributeTest {
 
     @Test
     public void testGroundCoverTrue() throws NitfFormatException {
-        when(tre.getIntValue(Constants.GRD_COVER)).thenReturn(1);
+        when(tre.getIntValue(NitfConstants.GRD_COVER)).thenReturn(1);
         Serializable actual = CsexraAttribute.SNOW_COVER.getAccessorFunction()
                 .apply(tre);
         assertThat(actual, is(instanceOf(Boolean.class)));
@@ -50,7 +50,7 @@ public class CsexraAttributeTest {
 
     @Test
     public void testGroundCoverFalse() throws NitfFormatException {
-        when(tre.getIntValue(Constants.GRD_COVER)).thenReturn(0);
+        when(tre.getIntValue(NitfConstants.GRD_COVER)).thenReturn(0);
         Serializable actual = CsexraAttribute.SNOW_COVER.getAccessorFunction()
                 .apply(tre);
         assertThat(actual, is(instanceOf(Boolean.class)));
@@ -59,24 +59,24 @@ public class CsexraAttributeTest {
 
     @Test
     public void testGroundCoverOther() throws NitfFormatException {
-        when(tre.getIntValue(Constants.GRD_COVER)).thenReturn(5);
+        when(tre.getIntValue(NitfConstants.GRD_COVER)).thenReturn(5);
         Serializable actual = CsexraAttribute.SNOW_COVER.getAccessorFunction()
                 .apply(tre);
-        assertThat(actual, is(nullValue()));
+        assertThat(actual, nullValue());
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testGroundCoverNotSet() throws NitfFormatException {
-        when(tre.getIntValue(Constants.GRD_COVER)).thenThrow(NitfFormatException.class);
+        when(tre.getIntValue(NitfConstants.GRD_COVER)).thenThrow(NitfFormatException.class);
         Serializable actual = CsexraAttribute.SNOW_COVER.getAccessorFunction()
                 .apply(tre);
-        assertThat(actual, is(nullValue()));
+        assertThat(actual, nullValue());
     }
 
     @Test
     public void testNiirs() throws NitfFormatException {
-        when(tre.getFieldValue(Constants.PREDICTED_NIIRS)).thenReturn("3.1");
+        when(tre.getFieldValue(NitfConstants.PREDICTED_NIIRS)).thenReturn("3.1");
 
         Serializable actual = CsexraAttribute.PREDICTED_NIIRS.getAccessorFunction()
                 .apply(tre);
@@ -88,30 +88,30 @@ public class CsexraAttributeTest {
 
     @Test
     public void testNiirsOther() throws NitfFormatException {
-        when(tre.getFieldValue(Constants.PREDICTED_NIIRS)).thenReturn("N/A");
+        when(tre.getFieldValue(NitfConstants.PREDICTED_NIIRS)).thenReturn("N/A");
 
         Serializable actual = CsexraAttribute.PREDICTED_NIIRS.getAccessorFunction()
                 .apply(tre);
 
-        assertThat(actual, is(nullValue()));
+        assertThat(actual, nullValue());
 
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testNiirsNotSet() throws NitfFormatException {
-        when(tre.getFieldValue(Constants.PREDICTED_NIIRS)).thenThrow(NitfFormatException.class);
+        when(tre.getFieldValue(NitfConstants.PREDICTED_NIIRS)).thenThrow(NitfFormatException.class);
 
         Serializable actual = CsexraAttribute.PREDICTED_NIIRS.getAccessorFunction()
                 .apply(tre);
 
-        assertThat(actual, is(nullValue()));
+        assertThat(actual, nullValue());
 
     }
 
     @Test
     public void testSnowDepthMinCategory0() throws NitfFormatException {
-        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(0);
+        when(tre.getIntValue(NitfConstants.SNOW_DEPTH_CAT)).thenReturn(0);
 
         Serializable actual = CsexraAttribute.SNOW_DEPTH_MIN.getAccessorFunction()
                 .apply(tre);
@@ -122,7 +122,7 @@ public class CsexraAttributeTest {
 
     @Test
     public void testSnowDepthMinCategory1() throws NitfFormatException {
-        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(1);
+        when(tre.getIntValue(NitfConstants.SNOW_DEPTH_CAT)).thenReturn(1);
 
         Serializable actual = CsexraAttribute.SNOW_DEPTH_MIN.getAccessorFunction()
                 .apply(tre);
@@ -133,7 +133,7 @@ public class CsexraAttributeTest {
 
     @Test
     public void testSnowDepthMinCategory2() throws NitfFormatException {
-        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(2);
+        when(tre.getIntValue(NitfConstants.SNOW_DEPTH_CAT)).thenReturn(2);
 
         Serializable actual = CsexraAttribute.SNOW_DEPTH_MIN.getAccessorFunction()
                 .apply(tre);
@@ -144,7 +144,7 @@ public class CsexraAttributeTest {
 
     @Test
     public void testSnowDepthMinCategory3() throws NitfFormatException {
-        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(3);
+        when(tre.getIntValue(NitfConstants.SNOW_DEPTH_CAT)).thenReturn(3);
 
         Serializable actual = CsexraAttribute.SNOW_DEPTH_MIN.getAccessorFunction()
                 .apply(tre);
@@ -155,28 +155,28 @@ public class CsexraAttributeTest {
 
     @Test
     public void testSnowDepthMinCategoryOther() throws NitfFormatException {
-        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(10);
+        when(tre.getIntValue(NitfConstants.SNOW_DEPTH_CAT)).thenReturn(10);
 
         Serializable actual = CsexraAttribute.SNOW_DEPTH_MIN.getAccessorFunction()
                 .apply(tre);
 
-        assertThat(actual, is(nullValue()));
+        assertThat(actual, nullValue());
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testSnowDepthMinCategoryNotSet() throws NitfFormatException {
-        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenThrow(NitfFormatException.class);
+        when(tre.getIntValue(NitfConstants.SNOW_DEPTH_CAT)).thenThrow(NitfFormatException.class);
 
         Serializable actual = CsexraAttribute.SNOW_DEPTH_MIN.getAccessorFunction()
                 .apply(tre);
 
-        assertThat(actual, is(nullValue()));
+        assertThat(actual, nullValue());
     }
 
     @Test
     public void testSnowDepthMaxCategory0() throws NitfFormatException {
-        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(0);
+        when(tre.getIntValue(NitfConstants.SNOW_DEPTH_CAT)).thenReturn(0);
 
         Serializable actual = CsexraAttribute.SNOW_DEPTH_MAX.getAccessorFunction()
                 .apply(tre);
@@ -187,7 +187,7 @@ public class CsexraAttributeTest {
 
     @Test
     public void testSnowDepthMaxCategory1() throws NitfFormatException {
-        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(1);
+        when(tre.getIntValue(NitfConstants.SNOW_DEPTH_CAT)).thenReturn(1);
 
         Serializable actual = CsexraAttribute.SNOW_DEPTH_MAX.getAccessorFunction()
                 .apply(tre);
@@ -198,7 +198,7 @@ public class CsexraAttributeTest {
 
     @Test
     public void testSnowDepthMaxCategory2() throws NitfFormatException {
-        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(2);
+        when(tre.getIntValue(NitfConstants.SNOW_DEPTH_CAT)).thenReturn(2);
 
         Serializable actual = CsexraAttribute.SNOW_DEPTH_MAX.getAccessorFunction()
                 .apply(tre);
@@ -209,7 +209,7 @@ public class CsexraAttributeTest {
 
     @Test
     public void testSnowDepthMaxCategory3() throws NitfFormatException {
-        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(3);
+        when(tre.getIntValue(NitfConstants.SNOW_DEPTH_CAT)).thenReturn(3);
 
         Serializable actual = CsexraAttribute.SNOW_DEPTH_MAX.getAccessorFunction()
                 .apply(tre);
@@ -220,23 +220,23 @@ public class CsexraAttributeTest {
 
     @Test
     public void testSnowDepthMaxCategoryOther() throws NitfFormatException {
-        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenReturn(10);
+        when(tre.getIntValue(NitfConstants.SNOW_DEPTH_CAT)).thenReturn(10);
 
         Serializable actual = CsexraAttribute.SNOW_DEPTH_MAX.getAccessorFunction()
                 .apply(tre);
 
-        assertThat(actual, is(nullValue()));
+        assertThat(actual, nullValue());
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testSnowDepthMaxCategoryNotSet() throws NitfFormatException {
-        when(tre.getIntValue(Constants.SNOW_DEPTH_CAT)).thenThrow(NitfFormatException.class);
+        when(tre.getIntValue(NitfConstants.SNOW_DEPTH_CAT)).thenThrow(NitfFormatException.class);
 
         Serializable actual = CsexraAttribute.SNOW_DEPTH_MAX.getAccessorFunction()
                 .apply(tre);
 
-        assertThat(actual, is(nullValue()));
+        assertThat(actual, nullValue());
     }
 
 }

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/PiaimcAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/PiaimcAttributeTest.java
@@ -39,7 +39,7 @@ public class PiaimcAttributeTest {
     @Test
     public void testCloudCover() throws NitfFormatException {
         for (int cloudCover = 0; cloudCover <= 100; cloudCover++) {
-            when(tre.getIntValue(Constants.CLOUDCVR)).thenReturn(cloudCover);
+            when(tre.getIntValue(NitfConstants.CLOUDCVR)).thenReturn(cloudCover);
             Serializable actual = PiaimcAttribute.CLOUDCVR.getAccessorFunction()
                     .apply(tre);
             assertThat(actual, is(instanceOf(Integer.class)));
@@ -49,27 +49,27 @@ public class PiaimcAttributeTest {
 
     @Test
     public void testCloudCoverTooLow() throws NitfFormatException {
-        when(tre.getIntValue(Constants.CLOUDCVR)).thenReturn(-10);
+        when(tre.getIntValue(NitfConstants.CLOUDCVR)).thenReturn(-10);
         Serializable actual = PiaimcAttribute.CLOUDCVR.getAccessorFunction()
                 .apply(tre);
-        assertThat(actual, is(nullValue()));
+        assertThat(actual, nullValue());
     }
 
     @Test
     public void testCloudCoverTooHigh() throws NitfFormatException {
-        when(tre.getIntValue(Constants.CLOUDCVR)).thenReturn(110);
+        when(tre.getIntValue(NitfConstants.CLOUDCVR)).thenReturn(110);
         Serializable actual = PiaimcAttribute.CLOUDCVR.getAccessorFunction()
                 .apply(tre);
-        assertThat(actual, is(nullValue()));
+        assertThat(actual, nullValue());
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testCloudCoverNotSet() throws NitfFormatException {
-        when(tre.getIntValue(Constants.CLOUDCVR)).thenThrow(NitfFormatException.class);
+        when(tre.getIntValue(NitfConstants.CLOUDCVR)).thenThrow(NitfFormatException.class);
         Serializable actual = PiaimcAttribute.CLOUDCVR.getAccessorFunction()
                 .apply(tre);
-        assertThat(actual, is(nullValue()));
+        assertThat(actual, nullValue());
     }
 
 }

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/PiaimcAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/PiaimcAttributeTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.common;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+
+import org.codice.imaging.nitf.core.common.NitfFormatException;
+import org.codice.imaging.nitf.core.tre.Tre;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PiaimcAttributeTest {
+
+    private Tre tre;
+
+    @Before
+    public void setup() {
+        tre = mock(Tre.class);
+    }
+
+    @Test
+    public void testCloudCover() throws NitfFormatException {
+        for (int cloudCover = 0; cloudCover <= 100; cloudCover++) {
+            when(tre.getIntValue(Constants.CLOUDCVR)).thenReturn(cloudCover);
+            Serializable actual = PiaimcAttribute.CLOUDCVR.getAccessorFunction()
+                    .apply(tre);
+            assertThat(actual, is(instanceOf(Integer.class)));
+            assertThat(actual, is(cloudCover));
+        }
+    }
+
+    @Test
+    public void testCloudCoverTooLow() throws NitfFormatException {
+        when(tre.getIntValue(Constants.CLOUDCVR)).thenReturn(-10);
+        Serializable actual = PiaimcAttribute.CLOUDCVR.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testCloudCoverTooHigh() throws NitfFormatException {
+        when(tre.getIntValue(Constants.CLOUDCVR)).thenReturn(110);
+        Serializable actual = PiaimcAttribute.CLOUDCVR.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testCloudCoverNotSet() throws NitfFormatException {
+        when(tre.getIntValue(Constants.CLOUDCVR)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.CLOUDCVR.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+}

--- a/catalog/security/banner-marking/pom.xml
+++ b/catalog/security/banner-marking/pom.xml
@@ -44,19 +44,13 @@
             <version>${ddf.version}</version>
         </dependency>
 
+        <!--Spock dependencies-->
         <dependency>
-            <groupId>org.spockframework</groupId>
-            <artifactId>spock-core</artifactId>
-            <version>1.0-groovy-2.4</version>
+            <groupId>ddf.lib</groupId>
+            <artifactId>spock-shaded</artifactId>
+            <version>${ddf.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>2.4.5</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <build>
@@ -115,19 +109,6 @@
                                 </rule>
                             </rules>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.gmavenplus</groupId>
-                <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.4</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>testCompile</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/catalog/transformer/catalog-transformer-mgmp/pom.xml
+++ b/catalog/transformer/catalog-transformer-mgmp/pom.xml
@@ -67,6 +67,11 @@
             <artifactId>spatial-csw-common</artifactId>
             <version>${ddf.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -114,7 +119,8 @@
                         <Embed-Dependency>
                             platform-util,
                             catalog-core-api-impl;groupId=org.codice.alliance.catalog.core,
-                            catalog-core-api-impl;groupId=ddf.catalog.core
+                            catalog-core-api-impl;groupId=ddf.catalog.core,
+                            commons-lang3
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                     </instructions>

--- a/catalog/transformer/catalog-transformer-mgmp/src/main/java/org/codice/alliance/catalog/transformer/mgmp/MgmpTransformer.java
+++ b/catalog/transformer/catalog-transformer-mgmp/src/main/java/org/codice/alliance/catalog/transformer/mgmp/MgmpTransformer.java
@@ -486,6 +486,16 @@ public class MgmpTransformer extends GmdTransformer {
         try (InputStream inputStream = getSourceInputStream()) {
             DocumentBuilderFactory domFactory = DocumentBuilderFactory.newInstance();
             domFactory.setNamespaceAware(false);
+            try {
+                domFactory.setFeature(
+                        "http://apache.org/xml/features/nonvalidating/load-dtd-grammar",
+                        false);
+                domFactory.setFeature(
+                        "http://apache.org/xml/features/nonvalidating/load-external-dtd",
+                        false);
+            } catch (ParserConfigurationException e) {
+                LOGGER.debug("Unable to set features on document builder.", e);
+            }
             DocumentBuilder builder = domFactory.newDocumentBuilder();
             Document document = builder.parse(inputStream);
 

--- a/catalog/video/video-admin-plugin/src/main/webapp/js/view/StreamMonitor.view.js
+++ b/catalog/video/video-admin-plugin/src/main/webapp/js/view/StreamMonitor.view.js
@@ -108,8 +108,8 @@ define([
             onRender: function() {
                 this.setupPopOver('[data-toggle="feed-name-popover"]', 'Title of the parent metacard.');
                 this.setupPopOver('[data-toggle="url-popover"]', 'Specifies the network address (e.g. udp://localhost:50000) to be monitored. The address must be resolvable.');
-                this.setupPopOver('[data-toggle="max-dur-popover"]', 'Maximum file size (MB) before rollover. Must be >=1.');
-                this.setupPopOver('[data-toggle="max-size-popover"]', 'Maximum elapsed time in minutes before rollover. Must be >=1.');
+                this.setupPopOver('[data-toggle="max-dur-popover"]', 'Maximum elapsed time in minutes before rollover. Must be >=1.');
+                this.setupPopOver('[data-toggle="max-size-popover"]', 'Maximum file size (MB) before rollover. Must be >=1.');
                 this.setupPopOver('[data-toggle="file-templ-popover"]', 'Filename template for each chunk. The template may contain any number of the sequence "%{date=FORMAT}" where FORMAT is a Java SimpleDateFormat. Must be non-blank.');
                 this.setupPopOver('[data-toggle="delay-popover"]', 'Delay updates when creating metacards to avoid retries. Slower systems require a longer delay. The minimum value is 0 seconds and the maximum value is 60 seconds. (seconds)');
                 this.setupPopOver('[data-toggle="distance-tolerance-popover"]', 'Distance tolerance used to simplify geospatial metadata during video stream processing. The tolerance must be non-negative and the units are degrees.');

--- a/catalog/video/video-mpegts-transformer/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/video/video-mpegts-transformer/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -18,7 +18,7 @@
          name="MPEG-TS Input Transformer"
          id="org.codice.alliance.transformer.video.MpegTsInputTransformer">
 
-        <AD description="Location polygon subsample count used to reduce the number the total number of polygons."
+        <AD description="Location polygon subsample count used to reduce the total number of polygons."
             name="Subsample Count" id="subsampleCount" required="true" type="Integer"
             default="50"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -384,6 +384,19 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--  We don't want to inherit this *change* to the plugin configuration. -->


### PR DESCRIPTION
#### What does this PR do?

The attributes being added to ISR are SNOW_COVER, SNOW_DEPTH_MIN and SNOW_DEPTH_MAX,
which are similar to existing ISR attributes. The metadata from the NITF TREs that
corresponding to other existing metacard attributes are extracted, normalized where
needed, and set.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@dcruver 
@lcrosenbu 
@roelens8 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@beyelerb
@kcwire
#### How should this be tested?

Just run the unit tests for now. If I find sample NITF files applicable to the new code, then I will update the PR.
#### Any background context you want to provide?

The ticket also called for HISTOA, but I couldn't find any corresponding metacard attributes.

This PR is based on the umerged work in CAL-79 (https://github.com/codice/alliance/pull/82). 

The unit tests cover the new code, but I am looking for NITF files that contain the fields addressed by this PR.
#### What are the relevant tickets?

CAL-132
CAL-79
#### Screenshots (if appropriate)
#### Checklist:
- [X] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
